### PR TITLE
feat(build,executor,cli): already-done node state

### DIFF
--- a/src/kiln/cli.py
+++ b/src/kiln/cli.py
@@ -1063,6 +1063,7 @@ def _build_status_table(
             "pending": "dim",
             "running": "yellow",
             "done": "green",
+            "already-done": "cyan",
             "failed": "red",
             "abandoned": "red",
             "wont-do": "dim",
@@ -1841,6 +1842,7 @@ def _launch_dashboard_tui() -> None:
 
     _STATE_COLOR = {
         "done": "green",
+        "already-done": "cyan",
         "running": "cyan",
         "pending": "yellow",
         "abandoned": "red",
@@ -2461,6 +2463,7 @@ _NODE_STATE_COLORS = {
     "pending": "dim",
     "running": "yellow",
     "done": "green",
+    "already-done": "cyan",
     "failed": "red",
     "abandoned": "red",
     "wont-do": "dim",

--- a/src/kiln/graph/executor.py
+++ b/src/kiln/graph/executor.py
@@ -52,7 +52,9 @@ class ExecutionGraph:
     def get_ready(self) -> list[GraphNode]:
         """Return pending nodes whose dependencies are all done/abandoned."""
         terminal: set[str] = {
-            nid for nid, n in self._nodes.items() if n.state in ("done", "abandoned")
+            nid
+            for nid, n in self._nodes.items()
+            if n.state in ("done", "abandoned", "already-done")
         }
         ready = []
         for node in self._nodes.values():
@@ -185,7 +187,12 @@ class GraphExecutor:
                 continue
             seen.add(node.id)
             existing = self._store.read_node(node.id)
-            if not existing or existing.state not in ("done", "abandoned", "wont-do"):
+            if not existing or existing.state not in (
+                "done",
+                "abandoned",
+                "wont-do",
+                "already-done",
+            ):
                 continue
             node.state = existing.state  # type: ignore[assignment]
             if existing.state == "wont-do":
@@ -197,7 +204,7 @@ class GraphExecutor:
                 node.state = "pending"  # type: ignore[assignment]
                 self._store.write_node(node)
                 continue
-            # state == "done"
+            # state == "done" or "already-done" — terminal success, don't re-dispatch
             node.output = existing.output
             result.done.append(node.id)
             # Replay plan node expansion so dependents are in the graph
@@ -418,7 +425,7 @@ class GraphExecutor:
                             self._store.write_node(n)
 
         if result.success:
-            node.state = "done"  # type: ignore[assignment]
+            node.state = "already-done" if result.already_done else "done"  # type: ignore[assignment]
             exec_result.done.append(node.id)
             # In dry-run mode nothing is persisted — a real run must start fresh.
             if self._dry_run:

--- a/src/kiln/graph/handlers/build.py
+++ b/src/kiln/graph/handlers/build.py
@@ -37,6 +37,14 @@ def _get_pr_number(repo: str, branch: str) -> int | None:
         return None
 
 
+def _is_issue_closed(repo: str, issue_number: int) -> bool:
+    r = _gh("issue", "view", str(issue_number), "--repo", repo, "--json", "state")
+    try:
+        return json.loads(r.stdout).get("state", "").upper() == "CLOSED"
+    except (json.JSONDecodeError, AttributeError):
+        return False
+
+
 def _claim_issue(repo: str, issue_number: int) -> None:
     _gh(
         "issue",
@@ -299,6 +307,22 @@ class BuildHandler:
                     break
 
         if not pr_number:
+            if issue_number and _is_issue_closed(repo, issue_number):
+                _gh(
+                    "issue",
+                    "comment",
+                    str(issue_number),
+                    "--repo",
+                    repo,
+                    "--body",
+                    "Work already present in codebase; kiln marking node already-done.",
+                )
+                _unclaim_issue(repo, issue_number)
+                return NodeResult(
+                    success=True,
+                    already_done=True,
+                    output={"already_done": True, "branch": branch},
+                )
             if issue_number:
                 _unclaim_issue(repo, issue_number)
             return NodeResult(success=False, error="agent completed but no PR found")

--- a/src/kiln/graph/handlers/merge.py
+++ b/src/kiln/graph/handlers/merge.py
@@ -357,6 +357,12 @@ Address every comment. Do not ignore any reviewer feedback."""
             build_node_id = node.context.get("build_node_id")
             if build_node_id and self._store:
                 build_node = self._store.read_node(build_node_id)
+                if build_node and build_node.state == "already-done":
+                    return NodeResult(
+                        success=True,
+                        already_done=True,
+                        output={"already_done": True},
+                    )
                 if build_node and build_node.state == "abandoned":
                     return NodeResult(
                         success=False,

--- a/src/kiln/graph/node.py
+++ b/src/kiln/graph/node.py
@@ -58,7 +58,7 @@ class NodeResult:
     duplicate PR detected).
     """
 
-    __slots__ = ("success", "output", "error", "abandon", "cost_usd")
+    __slots__ = ("success", "output", "error", "abandon", "already_done", "cost_usd")
 
     def __init__(
         self,
@@ -66,12 +66,14 @@ class NodeResult:
         output: dict[str, Any] | None = None,
         error: str | None = None,
         abandon: bool = False,
+        already_done: bool = False,
         cost_usd: float | None = None,
     ) -> None:
         self.success = success
         self.output = output or {}
         self.error = error
         self.abandon = abandon
+        self.already_done = already_done
         self.cost_usd = cost_usd
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Closes #2

When a build agent finds work already present and closes the issue without creating a PR, kiln previously retried 3× then abandoned the node.

**Changes:**
- `NodeResult` gains `already_done: bool = False`
- `BuildHandler`: after the 90s PR wait, if the issue is closed → comment on issue + return `already_done=True`
- `ExecutionGraph.get_ready()`: `already-done` is terminal (unblocks downstream)
- `_restore_from_store()`: `already-done` treated like `done` — not re-dispatched on restart
- `_handle_node_result()`: sets `node.state = "already-done"` when flag is set
- `MergeHandler`: build node `already-done` → merge node `already-done` (no PR to merge)
- CLI: `already-done` shown in cyan in all node state color maps